### PR TITLE
fix: 잘못된 api 수정(#9)

### DIFF
--- a/src/main/java/demago/khjv2/domain/user/presentation/AuthController.java
+++ b/src/main/java/demago/khjv2/domain/user/presentation/AuthController.java
@@ -11,7 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/v1/auth")
+@RequestMapping("/api/v2/auth")
 @RequiredArgsConstructor
 public class AuthController {
 


### PR DESCRIPTION
## Summary
- AuthController의 base path 오타를 수정합니다. (/api/v1/auth → /api/v2/auth)
- 기존에 구현된 /join, /login 엔드포인트가 의도한 v2 라우팅으로 정상 접근되도록 정리합니다.

## Related Issue
- Related: #9 

## Root Cause
- 컨트롤러 @RequestMapping 경로를 v1로 잘못 지정해 클라이언트/문서 기준(v2)과 실제 라우팅이 불일치했습니다.
- 그 결과 /api/v2/auth/** 요청이 컨트롤러에 매핑되지 않아 404 또는 인증 플로우가 정상 동작하지 않는 문제가 발생했습니다.

## Fix Description
- @RequestMapping("/api/v1/auth") → @RequestMapping("/api/v2/auth")로 수정

## Testing
- No response

## Risk & Impact
- Risk level: Low
- Risk: acces token이 만료될 시 로그인이 바로 종료됨

## Checklist
- No response